### PR TITLE
chore: fix dependabot config for pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,27 +8,3 @@ updates:
       all:
         patterns:
           - "*"
-  - package-ecosystem: "npm"
-    directory: "examples/nextjs/"
-    schedule:
-      interval: "monthly"
-    groups:
-      all:
-        patterns:
-          - "*"
-  - package-ecosystem: "npm"
-    directory: "packages/fetch/"
-    schedule:
-      interval: "monthly"
-    groups:
-      all:
-        patterns:
-          - "*"
-  - package-ecosystem: "npm"
-    directory: "packages/render/"
-    schedule:
-      interval: "monthly"
-    groups:
-      all:
-        patterns:
-          - "*"


### PR DESCRIPTION
Fixes Dependabot configuration for pnpm workspaces. Dependabot native pnpm workspace support requires only the root directory to be configured. The previous config caused Dependabot to create separate PRs for subpackages without updating the root `pnpm-lock.yaml`, which broke the CI.