### PR TITLE
chore: add mise.toml and use mise in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: |
-            - args: [--frozen-lockfile]
+      - name: Install mise
+        uses: jdx/mise-action@v2
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Check code format
         run: pnpm run format:check
       - name: Build packages

--- a/.github/workflows/examples-cd.yml
+++ b/.github/workflows/examples-cd.yml
@@ -31,16 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        #- name: Setup Node
-        #  uses: actions/setup-node@v4
-        #  with:
-        #    node-version: "20"
-        #    cache: "pnpm"
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
-          run_install: false
+      - name: Install mise
+        uses: jdx/mise-action@v2
       #- name: Setup Pages
       #  uses: actions/configure-pages@v5
       #  with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      #- uses: actions/setup-node@v4
-      #  with:
-      #    node-version: 16
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: |
-            - args: [--frozen-lockfile]
+      - name: Install mise
+        uses: jdx/mise-action@v2
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Build packages
         run: pnpm --filter './packages/*' run build
       - name: Set publishing config

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "24"
+pnpm = "9"


### PR DESCRIPTION
Pin Node 24 and pnpm 9 via mise. Replace pnpm/action-setup with jdx/mise-action in ci, release, and examples-cd workflows.